### PR TITLE
Add Re-exports of relevant types

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@ let
     ref = "master";
     rev = "15949d07dedbf95ad6536ac84be4d2f18dfa9523";
   };
-  ghc = pkgs.haskell.packages.ghc883.override {
+  ghc = pkgs.haskell.packages.ghc884.override {
     overrides = self: super: {
       monad-control-identity = self.callCabal2nix "monad-control-identity" "${src-monad-control-identity}" {};
     };

--- a/src/Network/Wai/Handler/WebSockets/Trans.hs
+++ b/src/Network/Wai/Handler/WebSockets/Trans.hs
@@ -15,14 +15,12 @@ module Network.Wai.Handler.WebSockets.Trans (
 -- * WebSocket
 , websocketsOrT
 
--- * Re-exports
+-- * Websocket type Re-exports
 , ServerApp
 , ClientApp
 , Connection
 , ConnectionOptions
 , PendingConnection
-, MonadBase
-, MonadBaseControlIdentity
 ) where
 
 import Control.Monad.Base ( MonadBase(..) )

--- a/src/Network/Wai/Handler/WebSockets/Trans.hs
+++ b/src/Network/Wai/Handler/WebSockets/Trans.hs
@@ -15,14 +15,29 @@ module Network.Wai.Handler.WebSockets.Trans (
 -- * WebSocket
 , websocketsOrT
 
+-- * Re-exports
+, ServerApp
+, ClientApp
+, Connection
+, ConnectionOptions
+, PendingConnection
+, MonadBase
+, MonadBaseControlIdentity
 ) where
 
-import Control.Monad.Base
+import Control.Monad.Base ( MonadBase(..) )
 import Control.Monad.Trans.Control.Identity
-import Network.Wai.Handler.WebSockets
+    ( MonadBaseControlIdentity(..) )
+import Network.Wai.Handler.WebSockets ( websocketsOr )
 import Network.WebSockets
+    ( ConnectionOptions,
+      ServerApp,
+      PendingConnection,
+      ClientApp,
+      Connection )
 
 import Network.Wai.Trans
+    ( MiddlewareT, liftApplication, runApplicationT )
 
 -- | A type synonym for a websockets 'ServerApp' which has been lifted from the 'IO' monad.
 type ServerAppT m = PendingConnection -> m ()

--- a/src/Network/Wai/Trans.hs
+++ b/src/Network/Wai/Trans.hs
@@ -12,12 +12,8 @@ module Network.Wai.Trans (
 , liftMiddleware
 , runMiddlewareT
 
-  -- * Re-exports
-, Application
-, Middleware
-, Request
-, Response
-, ResponseReceived
+  -- * Typeclass Re-exports
+, MonadBase
 , MonadBaseControlIdentity
 ) where
 

--- a/src/Network/Wai/Trans.hs
+++ b/src/Network/Wai/Trans.hs
@@ -12,11 +12,20 @@ module Network.Wai.Trans (
 , liftMiddleware
 , runMiddlewareT
 
+  -- * Re-exports
+, Application
+, Middleware
+, Request
+, Response
+, ResponseReceived
+, MonadBaseControlIdentity
 ) where
 
-import Control.Monad.Base
+import Control.Monad.Base ( MonadBase(liftBase) )
 import Control.Monad.Trans.Control.Identity
+    ( MonadBaseControlIdentity(..) )
 import Network.Wai
+    ( Application, Middleware, Request, Response, ResponseReceived )
 
 -- | A type synonym for a wai 'Application' which has been lifted from the 'IO' monad.
 type ApplicationT m = Request -> (Response -> m ResponseReceived) -> m ResponseReceived


### PR DESCRIPTION
This makes the modules easier to use, since you don’t have to add
e.g. monad-control-identity to your cabal file just to refer to the
class in a type signature.